### PR TITLE
ci: add PR build check workflow

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -1,0 +1,22 @@
+name: PR Build Check
+
+on:
+  pull_request:
+    branches: ["main"]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Build
+        run: npm run build


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that runs `npm ci` + `npm run build` on every PR targeting `main`.
- Catches dependency upgrades (dependabot/renovate) that break the eleventy build before merge.
- Also triggerable manually via `workflow_dispatch`.

## Test plan
- [x] Verified `npm run build` succeeds locally after js-yaml v5 fix
- [ ] Confirm workflow runs on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)